### PR TITLE
replace use of unsafe mem::transmute with enum_primative macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.bk
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "MIT"
 [dependencies]
 byteorder = "0.5"
 crc = "1.3.0"
-enum_primitive = "*"
+enum_primitive = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ license = "MIT"
 [dependencies]
 byteorder = "0.5"
 crc = "1.3.0"
+enum_primitive = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate enum_primitive;
 extern crate byteorder;
 extern crate crc;
 

--- a/src/wal/record.rs
+++ b/src/wal/record.rs
@@ -3,9 +3,10 @@ use crc::crc32;
 
 use std::io;
 use std::io::{Cursor, Read, Write};
-use std::mem;
 
-#[repr(u8)]
+use enum_primitive::FromPrimitive;
+
+enum_from_primitive! {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum RecordType {
     Zero = 1,
@@ -15,13 +16,11 @@ pub enum RecordType {
     Middle = 4,
     Last = 5,
 }
+}
 
 impl RecordType {
     pub fn from_u8(i: u8) -> Option<RecordType> {
-        if i >= RecordType::Zero as u8 && i <= RecordType::Last as u8 {
-            return Some(unsafe { mem::transmute(i) });
-        }
-        None
+        return RecordType::from_i32(i as i32)
     }
 }
 

--- a/src/wal/record.rs
+++ b/src/wal/record.rs
@@ -18,12 +18,6 @@ pub enum RecordType {
 }
 }
 
-impl RecordType {
-    pub fn from_u8(i: u8) -> Option<RecordType> {
-        return RecordType::from_i32(i as i32)
-    }
-}
-
 /// 32KB Block size.
 pub const BLOCK_SIZE: i64 = 32768;
 /// 7B Header size for record.

--- a/tests/test_record.rs
+++ b/tests/test_record.rs
@@ -62,14 +62,3 @@ fn test_read_write_invalid_record() {
         panic!("Reading invalid record with a smaller data size should return error");
     }
 }
-
-#[test]
-fn test_enum_primative() {
-    assert_eq!(None, RecordType::from_u8(0 as u8));
-    assert_eq!(Some(RecordType::Zero), RecordType::from_u8(1 as u8));
-    assert_eq!(Some(RecordType::Full), RecordType::from_u8(2 as u8));
-    assert_eq!(Some(RecordType::First), RecordType::from_u8(3 as u8));
-    assert_eq!(Some(RecordType::Middle), RecordType::from_u8(4 as u8));
-    assert_eq!(Some(RecordType::Last), RecordType::from_u8(5 as u8));
-    assert_eq!(None, RecordType::from_u8(6 as u8));
-}

--- a/tests/test_record.rs
+++ b/tests/test_record.rs
@@ -62,3 +62,14 @@ fn test_read_write_invalid_record() {
         panic!("Reading invalid record with a smaller data size should return error");
     }
 }
+
+#[test]
+fn test_enum_primative() {
+    assert_eq!(None, RecordType::from_u8(0 as u8));
+    assert_eq!(Some(RecordType::Zero), RecordType::from_u8(1 as u8));
+    assert_eq!(Some(RecordType::Full), RecordType::from_u8(2 as u8));
+    assert_eq!(Some(RecordType::First), RecordType::from_u8(3 as u8));
+    assert_eq!(Some(RecordType::Middle), RecordType::from_u8(4 as u8));
+    assert_eq!(Some(RecordType::Last), RecordType::from_u8(5 as u8));
+    assert_eq!(None, RecordType::from_u8(6 as u8));
+}


### PR DESCRIPTION
The use of  `unsafe { mem::transmute(i) }` in deserializing a RecordType sticks out. The code applies a `#[repr(u8)]` memory layout to RecordType to match the transmuted u8. Using a specified repr is documented as [disabling Rust's "null pointer optimization"](https://doc.rust-lang.org/nomicon/repr-rust.html) for `Option<RecordType>` and the method in question returns an `Option<RecordType>`. 

The same documentation page suggests that a u8 value may be "32-bit aligned on an architecture that aligns these primitives to their respective sizes". That suggests that forcing a u8 representation won't necessarily save any significant space over using Rust's defaults. 

This PR replaces the use of `unsafe` with the [`enum_primative` macro](https://docs.rs/enum_primitive/0.1.1/enum_primitive/). This simplifies the RecordType code at the expense of introducing an additional external crate dependency. As this gives compile time certainty that the code is safe it looks like a good trade-off. 